### PR TITLE
Add missing required field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,7 @@
 name=PPMEncoder
 version=0.1.0
 author=Christopher Schirner <schinken@bamberg.ccc.de>
+maintainer=Christopher Schirner <schinken@bamberg.ccc.de>
 sentence=A library to encode/generate a PPM signal for controlling RC Cars, etc...
 paragraph=Easy PPM Signal generator
 category=Signal Input/Output


### PR DESCRIPTION
When a required field is missing the Arduino IDE does not recognize the library:

- **Sketch > Include Library > Add .ZIP Library** fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Missing 'maintainer' from library" warnings are shown every time the libraries are scanned.
- Library Manager inclusion request is blocked.